### PR TITLE
Migrates Github actions (create-repo-github-*) from v1 to v2;

### DIFF
--- a/stackspot-actions/github/create-repo-github-and-set-secret-credential-stackspot/action.yaml
+++ b/stackspot-actions/github/create-repo-github-and-set-secret-credential-stackspot/action.yaml
@@ -1,10 +1,10 @@
-schema-version: v1
+schema-version: v2
 kind: action
 metadata:
   name: stakspot-gh-mk-repo-with-secrts
   display-name: Stackspot Create GitHub Repo With Secrets
   description: Action to create github repository With Secrets
-  version: 1.0.1
+  version: 2.0.0
 spec:
   type: python
   about: docs/about.md

--- a/stackspot-actions/github/create-repo-github/action.yaml
+++ b/stackspot-actions/github/create-repo-github/action.yaml
@@ -1,10 +1,10 @@
-schema-version: v1
+schema-version: v2
 kind: action
 metadata:
   name: stakspot-github-create-repository
   display-name: Stackspot Create GitHub Repository
   description: Action to create github repository if not exists
-  version: 1.0.2
+  version: 2.0.0
 spec:
   type: python
   about: docs/about.md


### PR DESCRIPTION
I had to publish the GitHub action (the simple one) into my StackSpot Personal account, but it was not possible because it was not in schema-version v2.

So, I ended up migrating both [Github actions](https://github.com/stack-spot/stackspot-workflows-action/tree/main/stackspot-actions/github): 
- [create-repo-github](https://github.com/stack-spot/stackspot-workflows-action/tree/main/stackspot-actions/github/create-repo-github)
- [create-repo-github-and-set-secret-credential-stackspot](https://github.com/stack-spot/stackspot-workflows-action/tree/main/stackspot-actions/github/create-repo-github-and-set-secret-credential-stackspot)

PS: Unfortunately, it's not possible to publish the action `create-repo-github-and-set-secret-credential-stackspot` due to [this issue](https://github.com/stack-spot/stacklifecycle-oscli/issues/1861).